### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,13 @@ setup(
     url='https://github.com/DevDungeon/issh',
     author='DevDungeon',
     author_email='nanodano@devdungeon.com',
-    license='GPL-3.0',
     py_modules=['issh'],
     scripts=scripts,
     zip_safe=False,
     install_requires=[
         requirements,
+    ],
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.