### PR TITLE
ignore wildcard entries

### DIFF
--- a/issh.py
+++ b/issh.py
@@ -37,7 +37,7 @@ class ISSH:
         with open(self.ssh_config_path) as ssh_config:
             for line in ssh_config.readlines():
                 line = line.rstrip()
-                if len(line) == 0 or line[0] == ' ' or line[0] == '\t' or line.lstrip()[0] == '#':
+                if len(line) == 0 or line[0] == ' ' or line[0] == '\t' or line.lstrip()[0] == '#' or line.find("*") > -1:
                     continue
                 try:
                     self.hosts.append(line.split()[1])


### PR DESCRIPTION
I got this error using `issh`

```
Traceback (most recent call last):
  File "/home/smk762/.local/bin/issh", line 8, in <module>
    sys.exit(main())
  File "/home/smk762/.local/lib/python3.8/site-packages/issh.py", line 146, in main
    curses.wrapper(main_wrapper)
  File "/usr/lib/python3.8/curses/__init__.py", line 105, in wrapper
    return func(stdscr, *args, **kwds)
  File "/home/smk762/.local/lib/python3.8/site-packages/issh.py", line 142, in main_wrapper
    issh.run()
  File "/home/smk762/.local/lib/python3.8/site-packages/issh.py", line 48, in run
    self.input_loop()
  File "/home/smk762/.local/lib/python3.8/site-packages/issh.py", line 64, in input_loop
    self.print_options()
  File "/home/smk762/.local/lib/python3.8/site-packages/issh.py", line 59, in print_options
    self.screen.addstr(i + num_header_rows, 0, "   %s" % (host))
_curses.error: addwstr() returned ERR
```

Managed to find the cause being use of a wildcard entry in my ssh config file like:

```
Host *
  IdentityFile ~/.ssh/id_ed25519
  port 22
  User dragon
```

This PR will exclude entries like this.