### PR TITLE
Allow longer host lists

### DIFF
--- a/issh.py
+++ b/issh.py
@@ -43,6 +43,7 @@ class ISSH:
                     self.hosts.append(line.split()[1])
                 except IndexError:
                     print(f"[-] Warning: Invalid host format detected on line: {line}")
+        self.hosts.sort()
 
     def run(self):
         self.input_loop()

--- a/issh.py
+++ b/issh.py
@@ -42,7 +42,7 @@ class ISSH:
                 try:
                     self.hosts.append(line.split()[1])
                 except IndexError:
-                    print('[-] Warning: Invalid host format detected on line: %s' % line)
+                    print(f"[-] Warning: Invalid host format detected on line: {line}")
 
     def run(self):
         self.input_loop()
@@ -52,11 +52,15 @@ class ISSH:
         num_header_rows = 2
         self.screen.addstr(0, 0, "Select an SSH host (Press H for help):")
 
-        for i, host in enumerate(self.hosts):
-            if i == self.active_choice:
-                self.screen.addstr(i + num_header_rows, 0, " > %s" % (host), curses.color_pair(1) | curses.A_BOLD)
-            else:
-                self.screen.addstr(i + num_header_rows, 0, "   %s" % (host))
+        for i, host in enumerate(self.hosts[self.active_choice:]):
+            try:
+                if i == 0:
+                    self.screen.addstr(i + num_header_rows, 0, f" > {host}", curses.color_pair(1) | curses.A_BOLD)
+                else:
+                    self.screen.addstr(i + num_header_rows, 0, f"   {host}")
+            except:
+                # Suppress error if list is longer than window
+                pass
         self.screen.refresh()
 
     def input_loop(self):
@@ -94,7 +98,7 @@ class ISSH:
 
         # After breaking out of loop, ssh to the active target
         self.cleanup_curses()
-        system('ssh %s' % self.hosts[self.active_choice])
+        system(f"ssh {self.hosts[self.active_choice]}")
 
     def cleanup_curses(self):
         self.screen.keypad(0)
@@ -115,7 +119,7 @@ class ISSH:
                 editor = 'nano'
             elif 'linux' in sys.platform:
                 editor = 'vi'
-        system("%s %s" % (editor, self.ssh_config_path))
+        system(f"{editor} {self.ssh_config_path}")
         self.load_ssh_hosts()  # Reload hosts after changes
 
     def print_help_screen(self):


### PR DESCRIPTION
I encountered another error case which would exit the app. When the ssh config file contains too many entries, the list becomes larger than the window. To be honest I think this was the actual cause for https://github.com/DevDungeon/issh/pull/2 as it returns the same error. 

To overcome this, I modified the curses options list to gracefully ignore the overflow, and instead of moving the selection down, move the list up.

While in the code I also updated some older style string formatting to use fstrings.